### PR TITLE
Ce/recursive

### DIFF
--- a/sparksql-scalapb/src/main/scala/com/trueaccord/scalapb/spark/ProtoSQL.scala
+++ b/sparksql-scalapb/src/main/scala/com/trueaccord/scalapb/spark/ProtoSQL.scala
@@ -70,7 +70,10 @@ object ProtoSQL {
       case ENUM => StringType
       case MESSAGE =>
         import collection.JavaConverters._
-        StructType(fd.getMessageType.getFields.asScala.map(structFieldFor))
+        StructType(fd.getMessageType.getFields.asScala.map( childFd =>
+          recursiveStructFieldFor(childFd, fd)
+        )
+      )
     }
   }
 

--- a/sparksql-scalapb/src/main/scala/com/trueaccord/scalapb/spark/ProtoSQL.scala
+++ b/sparksql-scalapb/src/main/scala/com/trueaccord/scalapb/spark/ProtoSQL.scala
@@ -82,4 +82,22 @@ object ProtoSQL {
       nullable = !fd.isRequired && !fd.isRepeated
     )
   }
+
+  def recursiveDataTypeFor(parentFd: FieldDescriptor, fd: FieldDescriptor) = {
+    import org.apache.spark.sql.types._
+    if (parentFd.getFullName() == fd.getFullName()) {
+      StringType
+    } else {
+      dataTypeFor(fd)
+    }
+  }
+
+  def recursiveStructFieldFor(fd: FieldDescriptor, parentFd: FieldDescriptor): StructField = {
+    val dataType = recursiveDataTypeFor(fd, parentFd)
+    StructField(
+      fd.getName,
+      if (fd.isRepeated) ArrayType(dataType, containsNull = false) else dataType,
+      nullable = !fd.isRequired && !fd.isRepeated
+    )
+  }
 }


### PR DESCRIPTION
OK, this is super gross, but here's the general idea:

The stack overflow is happening when the code attempts to build the schema, since it gets caught in an infinite loop when going down a recursively defined protobuf. I've defined corresponding "recursive" methods below which compare the FieldDescriptor of the parent message to that of the child message. If the message of the parent and the child have the same type (as in the case of a recursively defined protobuf), then it sets the Spark type of the child message to just be a String.

In the step where the code transforms the protobuf to a dataframe (`messageToRow`), I simply pass in the parent message on each call to `toRowData`, and if the parent message has the same type as the child message (again, as in the case of a recursively defined protobuf), it simply returns `null`.

Note that this *only* works in simple cases of recursively defined protobufs, where the type of the child is the same as the parent. It will still barf in cases where a grandchild message has the same type as the grandparent (e.g., an `Event` which contains a `View`, which contains an `Event`). I don't believe we have any cases of that, and we can discourage it from happening, but I don't think we can guarantee it.